### PR TITLE
Fix notify by invoking class method

### DIFF
--- a/lib/robokassa/interface.rb
+++ b/lib/robokassa/interface.rb
@@ -39,7 +39,7 @@ class Robokassa::Interface
   # This method verificates request params recived from robocassa server
   def notify(params, controller)
     parsed_params = map_params(params, @@notification_params_map)
-    notify_implementation(
+    self.class.notify_implementation(
       parsed_params[:invoice_id],
       parsed_params[:amount],
       parsed_params[:custom_options],


### PR DESCRIPTION
Пример notify в readme не работает из-за того, что метод notify_implementation принадлежит классу, а в notify вызывается метод экземпляра.
